### PR TITLE
Increase incident_key to 200 chars

### DIFF
--- a/openduty/migrations/0003_auto__chg_field_incident_incident_key.py
+++ b/openduty/migrations/0003_auto__chg_field_incident_incident_key.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Incident.incident_key'
+        db.alter_column(u'openduty_incident', 'incident_key', self.gf('django.db.models.fields.CharField')(max_length=200))
+
+    def backwards(self, orm):
+
+        # Changing field 'Incident.incident_key'
+        db.alter_column(u'openduty_incident', 'incident_key', self.gf('django.db.models.fields.CharField')(max_length=80))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'openduty.eventlog': {
+            'Meta': {'object_name': 'EventLog'},
+            'data': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'occurred_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'service_key': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openduty.Service']"})
+        },
+        u'openduty.incident': {
+            'Meta': {'unique_together': "(('service_key', 'incident_key'),)", 'object_name': 'Incident'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'details': ('django.db.models.fields.TextField', [], {}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '15'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'incident_key': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'occurred_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'service_key': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openduty.Service']"})
+        },
+        u'openduty.schedulepolicy': {
+            'Meta': {'object_name': 'SchedulePolicy'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'repeat_times': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'openduty.schedulepolicyrule': {
+            'Meta': {'object_name': 'SchedulePolicyRule'},
+            'escalate_after': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.IntegerField', [], {}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['schedule.Calendar']", 'null': 'True', 'blank': 'True'}),
+            'schedule_policy': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'rules'", 'to': u"orm['openduty.SchedulePolicy']"}),
+            'user_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        u'openduty.service': {
+            'Meta': {'object_name': 'Service'},
+            'escalate_after': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'policy': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openduty.SchedulePolicy']", 'null': 'True', 'blank': 'True'}),
+            'retry': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'openduty.servicetokens': {
+            'Meta': {'object_name': 'ServiceTokens'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'service_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openduty.Service']"}),
+            'token_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openduty.Token']"})
+        },
+        u'openduty.token': {
+            'Meta': {'object_name': 'Token'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '40', 'primary_key': 'True'})
+        },
+        u'openduty.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'pushover_app_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'pushover_user_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'slack_room_name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        'schedule.calendar': {
+            'Meta': {'object_name': 'Calendar'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['openduty']

--- a/openduty/models.py
+++ b/openduty/models.py
@@ -111,7 +111,7 @@ class Incident(models.Model):
     Incidents are representations of a malfunction in the system.
     """
     service_key = models.ForeignKey(Service)
-    incident_key = models.CharField(max_length=80)
+    incident_key = models.CharField(max_length=200)
     event_type = models.CharField(max_length=15)
     description = models.CharField(max_length=100)
     details = models.TextField()


### PR DESCRIPTION
With descriptive hostnames in Icinga we regularly get incident key lengths > 100 characters, so creating new events via the api results in the error below. CharFields become varchars in sqlite and MySQL at least and they're cheap so set it much higher

'Error code: 400, Reason: {"errors": ["Ensure this value has at most 80 characters (it has 107)."]}'
