### PR TITLE
Fix broken reprs on notification models

### DIFF
--- a/notification/models.py
+++ b/notification/models.py
@@ -32,7 +32,7 @@ class UserNotificationMethod(models.Model):
         db_table = 'openduty_usernotificationmethod'
 
     def __str__(self):
-        return self.id
+        return str(self.id)
 
 
 @python_2_unicode_compatible
@@ -49,7 +49,7 @@ class ScheduledNotification(models.Model):
         db_table = 'openduty_schedulednotification'
 
     def __str__(self):
-        return self.id
+        return str(self.id)
 
     @staticmethod
     def remove_all_for_incident(incident):


### PR DESCRIPTION
Was getting things like this poking around in the shell:

> > > u.notification_methods.all()
> > > Traceback (most recent call last):
> > >   File "<console>", line 1, in <module>
> > >   File "/opt/openduty/venv/local/lib/python2.7/site-packages/django/db/models/query.py", line 74, in **repr**
> > >     return repr(data)
> > >   File "/opt/openduty/venv/local/lib/python2.7/site-packages/django/db/models/base.py", line 423, in **repr**
> > >     u = six.text_type(self)
> > > TypeError: coercing to Unicode: need string or buffer, int found
