### PR TITLE
always use python 2 for virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 test_sqlite.db
 .idea/*
 env/*
+venv/*
 26env/*
 *.pyc
 database.sql

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ STATICFILES_DIRS = (
 ```
 sudo easy_install pip
 sudo pip install virtualenv
-virtualenv env
+virtualenv env --python python2.7
 . env/bin/activate
 pip install -r requirements.txt
 export DJANGO_SETTINGS_MODULE=openduty.settings_dev


### PR DESCRIPTION
Multiple distributions are switching to python 3 as default. It seems like this project depends on python 2. It should therefore reference it explicitly.