### PR TITLE
List active incidents

### DIFF
--- a/openduty/incidents.py
+++ b/openduty/incidents.py
@@ -13,7 +13,8 @@ from rest_framework import viewsets
 from .serializers import IncidentSerializer
 from rest_framework import status
 from rest_framework.response import Response
-from django.http import HttpResponseRedirect
+from django.core import serializers
+from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from django.core.exceptions import ValidationError
@@ -294,6 +295,13 @@ def silence(request, incident_id):
         return HttpResponseRedirect(url)
     except Service.DoesNotExist:
         raise Http404
+
+@require_http_methods(['GET'])
+def active_incidents(request):
+    incidents = Incident.objects.filter(event_type=Incident.TRIGGER)
+    serialized_incidents = serializers.serialize("json", incidents)
+    return HttpResponse(serialized_incidents,
+                        content_type="application/json")
 
 @login_required()
 @require_http_methods(["POST"])

--- a/openduty/urls.py
+++ b/openduty/urls.py
@@ -89,6 +89,7 @@ urlpatterns = patterns('',
     url(r'^dashboard/service/(.*)$', 'openduty.event_log.get'),
 
     #INCIDENTS
+    url(r'^incidents/active/$', 'openduty.incidents.active_incidents'),
     url(r'^incidents/details/(.*)$', 'openduty.incidents.details'),
     url(r'^incidents/update_type/$', 'openduty.incidents.update_type'),
     url(r'^incidents/forward_incident', 'openduty.incidents.forward_incident'),


### PR DESCRIPTION
So we can help API users avoid sending two similar incidents. Or if people would just like to consume current active incidents (for instrumentation or something else)